### PR TITLE
[TINK-1] fix launch local time

### DIFF
--- a/src/components/launch.js
+++ b/src/components/launch.js
@@ -19,10 +19,11 @@ import {
   Stack,
   AspectRatioBox,
   StatGroup,
+  Tooltip,
 } from "@chakra-ui/core";
 
 import { useSpaceX } from "../utils/use-space-x";
-import { formatDateTime } from "../utils/format-date";
+import { formatLocalDateTime, formatDateTime } from "../utils/format-date";
 import Error from "./error";
 import Breadcrumbs from "./breadcrumbs";
 
@@ -123,8 +124,19 @@ function TimeAndLocation({ launch }) {
             Launch Date
           </Box>
         </StatLabel>
+
         <StatNumber fontSize={["md", "xl"]}>
-          {formatDateTime(launch.launch_date_local)}
+          <Tooltip
+            label={`${formatDateTime(
+              launch.launch_date_local
+            )} in your local time`}
+          >
+            {/* Since we are getting the date we need directly from SpaceX's API,
+            we can parse it out and format it as needed. UTC Strings are standardized -
+            so the parser should work for all UTC DateTime Strings */}
+
+            {formatLocalDateTime(launch.launch_date_local)}
+          </Tooltip>
         </StatNumber>
         <StatHelpText>{timeAgo(launch.launch_date_utc)}</StatHelpText>
       </Stat>

--- a/src/components/launches.js
+++ b/src/components/launches.js
@@ -113,7 +113,7 @@ export function LaunchItem({ launch }) {
         <Flex>
           <Text fontSize="sm">{formatDate(launch.launch_date_utc)} </Text>
           <Text color="gray.500" ml="2" fontSize="sm">
-            {timeAgo(launch.launch_date_utc)}
+            {timeAgo(launch.launch_date_local)}
           </Text>
         </Flex>
       </Box>

--- a/src/utils/__tests__/format-date.js
+++ b/src/utils/__tests__/format-date.js
@@ -1,0 +1,21 @@
+import { formatDateTime, formatLocalDateTime } from "../format-date";
+
+describe("DateFormatters", () => {
+  test("it should be able to parse a UTC String", () => {
+    const formattedDate = formatLocalDateTime("2020-12-19T11:05:00+02:00");
+    expect(formattedDate).toEqual(
+      "Saturday, December 19, 2020 11:05:00 GMT +02:00"
+    );
+  });
+
+  test("Date only string is formatted with the default formatter", () => {
+    //time is assumed to be absolutely set to midnight when missing in the UTC string
+    const formattedDate = formatLocalDateTime("2020-12-19");
+    expect(formattedDate).toEqual(formatDateTime("2020-12-19"));
+  });
+
+  test("local and default datetime formatters are consistent in behaviour regarding null inputs", () => {
+    const formattedDate1 = formatLocalDateTime(null);
+    expect(formattedDate1).toEqual(formatDateTime(null));
+  });
+});

--- a/src/utils/format-date.js
+++ b/src/utils/format-date.js
@@ -18,3 +18,20 @@ export function formatDateTime(timestamp) {
     timeZoneName: "short",
   }).format(new Date(timestamp));
 }
+
+export function formatLocalDateTime(timestamp) {
+  if (!timestamp || typeof timestamp !== "string") {
+    return formatDateTime(timestamp);
+  }
+
+  const dateTimeRegex = /(....-..-..)T(..:..:..)(.*)/; //probably a better way to write this
+  const launchLocalDateTimeParts = dateTimeRegex.exec(timestamp);
+
+  if (!launchLocalDateTimeParts || launchLocalDateTimeParts && launchLocalDateTimeParts.length != 4) {
+    return formatDateTime(timestamp);
+  }
+
+  return `${formatDate(timestamp)} ${
+    launchLocalDateTimeParts[2]
+  } ${`GMT ${launchLocalDateTimeParts[3]}`}`;
+}


### PR DESCRIPTION
Fix TINK-1

- View local time as main display while viewing launch details
- View launch time in user's timezone in a tooltip
- Test for custom date time parser + formatter